### PR TITLE
Update Local Variables to improve usability

### DIFF
--- a/NMI Reconciling/v1.0/install/run.sql
+++ b/NMI Reconciling/v1.0/install/run.sql
@@ -725,4 +725,4 @@ declare @newblock as Int = (Select SCOPE_IDENTITY())
 Insert Into HTMLContent 
 ([BlockId],[Version],[Content],[IsApproved],[ApprovedDateTime],[Guid],[CreatedDateTime],[ModifiedDateTime])
 VALUES 
-(@newblock,1,@HTMLCONTENT,1,GetDate(),@HTMLContent,GetDate(),GetDate())
+(@newblock,1,@HTMLCONTENTCONTENT,1,GetDate(),@HTMLContent,GetDate(),GetDate())

--- a/NMI Reconciling/v1.0/install/run.sql
+++ b/NMI Reconciling/v1.0/install/run.sql
@@ -701,7 +701,7 @@ VALUES
 
 Declare @ParentId Int = (Select [Id] From Page Where [Guid] = '8c586b41-5861-46c3-91df-d2f2c2e5046c')
 
-Declare @HTMLCONTENT Varchar(max) = '{[ batchlist daysback:''21'' depositaccountname:''Deposit Account'' depositaccountglcode:'''']}'
+Declare @HTMLCONTENTCONTENT Varchar(max) = '{[ batchlist daysback:''21'' depositaccountname:''Deposit Account'' depositaccountglcode:'''']}'
 
 
 Insert Into Page 


### PR DESCRIPTION
The local variable @HTMLCONTENT is declared twice. This is not ideal, and at a minimum the code doesn't work in a DBMS connected to a Rock DB. I don't know if this code works as part of a package. This PR changes the second local variable declaration to use a different variable name, along with modifying the reference to the 2nd local variable.

I'm unsure if any changes would also need to be made to the uninstall sql, as it only references GUID's, and the second 'HTMLCONTENT' local variable is not a GUID, but a Varchar.